### PR TITLE
<sources/> handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,28 @@ bin
 obj
 *.suo
 *.user
+
+#ignore thumbnails created by windows
+Thumbs.db
+#Ignore files build by Visual Studio
+*.obj
+*.exe
+*.pdb
+*.aps
+*.pch
+*.vspscc
+*_i.c
+*_p.c
+*.ncb
+*.tlb
+*.tlh
+*.bak
+*.cache
+*.ilk
+*.log
+[Dd]ebug*/
+*.lib
+*.sbr
+[Rr]elease*/
+_ReSharper*/
+[Tt]est[Rr]esult*


### PR DESCRIPTION
This code enables Jenkins Cobertura plugin to display and parse the coverage report properly. The method signatures are still reported a bit strangely and Conditionals data is missing, but the report is quite usable as it is.
