### PR TITLE
Added option to include getters and setters which previously was ignored

### DIFF
--- a/OpenCoverToCoberturaConverter/Converter.cs
+++ b/OpenCoverToCoberturaConverter/Converter.cs
@@ -10,7 +10,7 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
 {
     public static class Converter
     {
-        public static XDocument ConvertToCobertura(XDocument openCoverReport, string sourcesDirectory)
+        public static XDocument ConvertToCobertura(XDocument openCoverReport, string sourcesDirectory, bool includeGettersSetters)
         {
             if (openCoverReport == null)
             {
@@ -22,13 +22,13 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
                 sourcesDirectory = sourcesDirectory.Replace("/", "\\");
             }
 
-            XDocument result = new XDocument(new XDeclaration("1.0", null, null), CreateRootElement(openCoverReport, sourcesDirectory));
+            XDocument result = new XDocument(new XDeclaration("1.0", null, null), CreateRootElement(openCoverReport, sourcesDirectory, includeGettersSetters));
             result.AddFirst(new XDocumentType("coverage", null, "http://cobertura.sourceforge.net/xml/coverage-04.dtd", null));
 
             return result;
         }
 
-        private static XElement CreateRootElement(XDocument openCoverReport, string sourcesDirectory)
+        private static XElement CreateRootElement(XDocument openCoverReport, string sourcesDirectory, bool includeGettersSetters)
         {
             long coveredLines = 0;
             long totalLines = 0;
@@ -42,7 +42,7 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
 
             rootElement.Add(CreateSourcesElement(openCoverReport, sourcesDirectory, out commonPrefix));
             var rootPrefixRegex = new Regex("^" + Regex.Escape(commonPrefix), RegexOptions.IgnoreCase);
-            rootElement.Add(CreatePackagesElement(openCoverReport, ref coveredLines, ref totalLines, ref coveredBranches, ref totalBranches, rootPrefixRegex));
+            rootElement.Add(CreatePackagesElement(openCoverReport, includeGettersSetters, ref coveredLines, ref totalLines, ref coveredBranches, ref totalBranches, rootPrefixRegex));
 
             double lineRate = totalLines == 0 ? 1 : coveredLines / (double)totalLines;
             double branchRate = totalBranches == 0 ? 1 : coveredBranches / (double)totalBranches;
@@ -114,7 +114,7 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
             return sources;
         }
 
-        private static XElement CreatePackagesElement(XDocument openCoverReport, ref long coveredLines, ref long totalLines, ref long coveredBranches, ref long totalBranches, Regex commonPrefix)
+        private static XElement CreatePackagesElement(XDocument openCoverReport, bool includeGettersSetters, ref long coveredLines, ref long totalLines, ref long coveredBranches, ref long totalBranches, Regex commonPrefix)
         {
             var packagesElement = new XElement("packages");
 
@@ -126,13 +126,13 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
 
             foreach (var module in modules)
             {
-                packagesElement.Add(CreatePackageElement(module, ref coveredLines, ref totalLines, ref coveredBranches, ref totalBranches, commonPrefix));
+                packagesElement.Add(CreatePackageElement(module, includeGettersSetters, ref coveredLines, ref totalLines, ref coveredBranches, ref totalBranches, commonPrefix));
             }
 
             return packagesElement;
         }
 
-        private static XElement CreatePackageElement(XElement module, ref long coveredLines, ref long totalLines, ref long coveredBranches, ref long totalBranches, Regex commonPrefix)
+        private static XElement CreatePackageElement(XElement module, bool includeGettersSetters, ref long coveredLines, ref long totalLines, ref long coveredBranches, ref long totalBranches, Regex commonPrefix)
         {
             long packageCoveredLines = 0;
             long packageTotalLines = 0;
@@ -166,7 +166,7 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
 
             foreach (var className in classNames)
             {
-                classesElement.Add(CreateClassElement(className, module, filesById, ref packageCoveredLines, ref packageTotalLines, ref packageCoveredBranches, ref packageTotalBranches, commonPrefix));
+                classesElement.Add(CreateClassElement(className, module, filesById, includeGettersSetters, ref packageCoveredLines, ref packageTotalLines, ref packageCoveredBranches, ref packageTotalBranches, commonPrefix));
             }
 
             double lineRate = packageTotalLines == 0 ? 1 : packageCoveredLines / (double)packageTotalLines;
@@ -191,7 +191,7 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
             return packageElement;
         }
 
-        private static XElement CreateClassElement(string className, XElement module, Dictionary<string, string> filesById, ref long coveredLines, ref long totalLines, ref long coveredBranches, ref long totalBranches, Regex commonPrefix)
+        private static XElement CreateClassElement(string className, XElement module, Dictionary<string, string> filesById, bool includeGettersSetters, ref long coveredLines, ref long totalLines, ref long coveredBranches, ref long totalBranches, Regex commonPrefix)
         {
             long classCoveredLines = 0;
             long classTotalLines = 0;
@@ -230,12 +230,15 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
                 .Elements("Methods")
                 .Elements("Method")
                 .Where(m => m.Attribute("skippedDueTo") == null
-                          && !m.HasAttributeWithValue("isGetter", "true")
-                          && !m.HasAttributeWithValue("isSetter", "true")
-                          && !Regex.IsMatch(m.Element("Name").Value, "::<.+>.+__"))
-                .ToArray();
+                            && !Regex.IsMatch(m.Element("Name").Value, "::<.+>.+__"));
 
-            foreach (var method in methods)
+            if (!includeGettersSetters)
+            {
+                methods = methods.Where(m => !m.HasAttributeWithValue("isGetter", "true")
+                                             && !m.HasAttributeWithValue("isSetter", "true"));
+            }
+
+            foreach (var method in methods.ToArray())
             {
                 var newMethodElement = CreateMethodElement(module, method, linesElement, ref classCoveredLines, ref classTotalLines, ref classCoveredBranches, ref classTotalBranches);
                 if (newMethodElement != null)

--- a/OpenCoverToCoberturaConverter/Program.cs
+++ b/OpenCoverToCoberturaConverter/Program.cs
@@ -45,6 +45,16 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
                 Console.WriteLine("Sources directory not set, will try to guess. This might not work properly when merging results from multiple test assemblies.");
             }
 
+            string includeGettersSettersString = null;
+            bool includeGetSet = false;
+            if (namedArguments.TryGetValue("INCLUDEGETTERSSETTERS", out includeGettersSettersString))
+            {
+                if (!bool.TryParse(includeGettersSettersString, out includeGetSet))
+                {
+                    Console.WriteLine("Unable to determine if getters/setters should be included or not. Ignoring for now.");
+                }
+            }
+
             if (!File.Exists(inputFile))
             {
                 Console.WriteLine("Report does not exist: " + inputFile);
@@ -63,7 +73,7 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
                 return 1;
             }
 
-            XDocument targetReport = Converter.ConvertToCobertura(inputReport, sourcesDirectory);
+            XDocument targetReport = Converter.ConvertToCobertura(inputReport, sourcesDirectory, includeGetSet);
 
             try
             {
@@ -85,6 +95,7 @@ namespace Palmmedia.OpenCoverToCoberturaConverter
             Console.WriteLine("[\"]-input:<OpenCover Report>[\"]");
             Console.WriteLine("[\"]-output:<Cobertura Report>[\"]");
             Console.WriteLine("[\"]-sources:<Solution Base Directory>[\"]");
+            Console.WriteLine("[\"]-includeGettersSetters:<true/false> (default: false)[\"]");
 
             Console.WriteLine();
             Console.WriteLine("Example:");


### PR DESCRIPTION
We want to switch our Jenkins reports from OpenCover to Cobertura to make it more consistent across our stuff, but we have logic in getters and setters that we want to have see the coverage off. So added a simple option to include those when converting.